### PR TITLE
Reconfigure servers in 2a cluster

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -49,16 +49,18 @@ Vagrant.configure("2") do |config|
             # mimics AWS dynamic inventory generated group based on instance
             # tag of Name=gluster-mgmt
             "tag_Name_gluster_mgmt" => ["jumper"],
-            # tag of gluster-master=us-east-2-c00
-            "tag_gluster_master_us_east_2_c00" => ["node1"],
+            # tag of gluster-master=us-east-2a-c00
+            "tag_gluster_master_us_east_2a_c00" => ["node0"],
             # ec2 tag: gluster-group=us-east-2-c00-g00
-            "tag_gluster_group_us_east_2_c00_g00" => [
+            "tag_gluster_group_us_east_2a_c00_g00" => [
               "node0",
               "node1",
               "node2"
             ],
-            # ec2 tag: gluster-group=us-east-2-c00-g01
-            "tag_gluster_group_us_east_2_c00_g01" => [
+            # tag of gluster-master=us-east-2a-c01
+            "tag_gluster_master_us_east_2a_c01" => ["node3"],
+            # ec2 tag: gluster-group=us-east-2-c01-g00
+            "tag_gluster_group_us_east_2a_c01_g00" => [
               "node3",
               "node4",
               "node5"

--- a/group_vars/gluster-servers
+++ b/group_vars/gluster-servers
@@ -3,11 +3,11 @@ gluster_volumes:
   supervol00:
     size: 500G
     device: /dev/xvdb
-    group: tag_gluster_group_us_east_2_c00_g00
+    group: tag_gluster_group_us_east_2a_c00_g00
   supervol01:
     size: 500G
     device: /dev/xvdb
-    group: tag_gluster_group_us_east_2_c00_g01
+    group: tag_gluster_group_us_east_2a_c01_g00
 
 # Number of snapshots to retain per supervol
 max_gluster_snaphots: 7

--- a/inventory_groups
+++ b/inventory_groups
@@ -1,14 +1,22 @@
-[g-us-east-2-c00:vars]
-cluster_master="{{ groups['tag_gluster_master_us_east_2_c00'][0] }}"
+#-- 2a cluster 00
+[g-us-east-2a-c00:vars]
+cluster_master="{{ groups['tag_gluster_master_us_east_2a_c00'][0] }}"
 
-# Server groups in the cluster
-[g-us-east-2-c00:children]
-tag_gluster_group_us_east_2_c00_g00
-tag_gluster_group_us_east_2_c00_g01
+[g-us-east-2a-c00:children]
+tag_gluster_group_us_east_2a_c00_g00
+
+#-- 2a cluster 01
+[g-us-east-2a-c01:vars]
+cluster_master="{{ groups['tag_gluster_master_us_east_2a_c01'][0] }}"
+
+[g-us-east-2a-c01:children]
+tag_gluster_group_us_east_2a_c01_g00
+
 
 [gluster-servers:children]
 # List all clusters as children of gluster-servers
-g-us-east-2-c00
+g-us-east-2a-c00
+g-us-east-2a-c01
 
 # The machine that will aggregate the pcp data from the gluster servers
 [pcp-aggregators:children]

--- a/roles/gluster-volume/tasks/main.yml
+++ b/roles/gluster-volume/tasks/main.yml
@@ -55,7 +55,7 @@
 - name: Mount brick
   mount:
     fstype: xfs
-    opts: inode64,discard
+    opts: inode64,discard,prjquota
     path: /bricks/{{ volume }}
     src: /dev/mapper/{{ volume }}-{{ volume }}
     state: mounted

--- a/site.yml
+++ b/site.yml
@@ -33,6 +33,10 @@
 - import_playbook: playbooks/gluster-volume.yml
 
 
+# Install pcp collection on jump host
+- import_playbook: playbooks/install-jumphost.yml
+
+
 # Need to add managed reboot sequence here
 # Reboot by AZ, ensuring hosts are up & healed before each reboot
 # Conditions:


### PR DESCRIPTION
This PR reconfigures the gluster servers for the starter-us-east-2a ocp cluster.
- [x] Split into 2 clusters
- [x] Enable xfs quota on brick mounts in preparation for removing gluster quota
- [x] Update Vagrantfile to match new AWS tags
- [x] Test via Vagrant