### PR TITLE
Add starter-us-east-1a config

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -64,7 +64,12 @@ Vagrant.configure("2") do |config|
               "node3",
               "node4",
               "node5"
-            ]
+            ],
+            # tags that need to exist for the config to parse correctly
+            "tag_gluster_master_us_east_1a_c00" => ["dummy"],
+            "tag_gluster_group_us_east_1a_c00_g00" => ["dummy"],
+            "tag_gluster_master_us_east_1a_c01" => ["dummy"],
+            "tag_gluster_group_us_east_1a_c01_g00" => ["dummy"]
           }
           ansible.limit = "all"
           ansible.playbook = "vagrant.yml"

--- a/ec2.ini
+++ b/ec2.ini
@@ -13,7 +13,7 @@
 # separated list of regions. E.g. 'us-east-1,us-west-1,us-west-2' and do not
 # provide the 'regions_exclude' option. If this is set to 'auto', AWS_REGION or
 # AWS_DEFAULT_REGION environment variable will be read to determine the region.
-regions = us-east-2
+regions = us-east-1,us-east-2
 regions_exclude = us-gov-west-1, cn-north-1
 
 # When generating inventory, Ansible needs to know how to address a server.

--- a/group_vars/ami_7a96b801
+++ b/group_vars/ami_7a96b801
@@ -1,0 +1,2 @@
+# RHEL-7.4_HVM_GA-20170808-x86_64-2-Access2-GP2 (ami-7a96b801)
+ansible_user: 'ec2-user'

--- a/group_vars/gluster-servers
+++ b/group_vars/gluster-servers
@@ -1,5 +1,13 @@
 # Defines the volumes exported by gluster
 gluster_volumes:
+  supervole1a00:
+    size: 500G
+    device: /dev/xvdb
+    group: tag_gluster_group_us_east_1a_c00_g00
+  supervole1a01:
+    size: 500G
+    device: /dev/xvdb
+    group: tag_gluster_group_us_east_1a_c01_g00
   supervol00:
     size: 500G
     device: /dev/xvdb

--- a/inventory_groups
+++ b/inventory_groups
@@ -1,3 +1,19 @@
+#-- 1a cluster 00
+[g-us-east-1a-c00:vars]
+cluster_master="{{ groups['tag_gluster_master_us_east_1a_c00'][0] }}"
+
+[g-us-east-1a-c00:children]
+tag_gluster_group_us_east_1a_c00_g00
+
+#-- 1a cluster 01
+[g-us-east-1a-c01:vars]
+cluster_master="{{ groups['tag_gluster_master_us_east_1a_c01'][0] }}"
+
+[g-us-east-1a-c01:children]
+tag_gluster_group_us_east_1a_c01_g00
+
+
+
 #-- 2a cluster 00
 [g-us-east-2a-c00:vars]
 cluster_master="{{ groups['tag_gluster_master_us_east_2a_c00'][0] }}"
@@ -13,8 +29,11 @@ cluster_master="{{ groups['tag_gluster_master_us_east_2a_c01'][0] }}"
 tag_gluster_group_us_east_2a_c01_g00
 
 
+
 [gluster-servers:children]
 # List all clusters as children of gluster-servers
+g-us-east-1a-c00
+g-us-east-1a-c01
 g-us-east-2a-c00
 g-us-east-2a-c01
 


### PR DESCRIPTION
- Adjust ec2.ini to also query us-east1
- Add group_vars (holding username) for new ami in east1
- Add cluster configuration in inventory_groups
- Add supervol definitions in gluster-servers
- Add dummy groups to Vagrantfile to prevent errors

Signed-off-by: John Strunk <jstrunk@redhat.com>