### PR TITLE
Fix how pcp collectors are added

### DIFF
--- a/playbooks/install-jumphost.yml
+++ b/playbooks/install-jumphost.yml
@@ -1,12 +1,6 @@
 # vim: set ts=2 sw=2 et :
 ---
 
-- name: Collect info from servers
-  hosts: gluster-servers
-  become: false
-  tasks:
-  - ping:
-
 - name: Install PCP aggregation
   hosts: pcp-aggregators
   become: true

--- a/roles/pcp-aggregator/tasks/main.yml
+++ b/roles/pcp-aggregator/tasks/main.yml
@@ -29,16 +29,28 @@
   - /etc/pcp/pmmgr/target-discovery.example-avahi
 
 
+- name: "Install bind-utils to get 'host'"
+  package:
+    name: bind-utils
+    state: present
+
+- name: Reverse lookup server IPs
+  shell: "host {{ item }} | awk '{ print $5 }' | sed -r 's/(.*)\\./\\1/'"
+  with_items:
+  - "{{ groups['gluster-servers'] |
+        map('extract', hostvars, 'ansible_host') |
+        list }}"
+  changed_when: false
+  register: hostnames
+
 - name: Set up list of hosts to monitor
   lineinfile:
     create: yes
-    line: "{{ item }}"
+    line: "{{ item.stdout }}"
     path: /etc/pcp/pmmgr/target-host
     state: present
   with_items:
-  - "{{ groups['gluster-servers'] |
-        map('extract', hostvars, 'ansible_fqdn') |
-        list }}"
+  - "{{ hostnames.results }}"
 
 - name: Relay metrics to Zabbix
   lineinfile:


### PR DESCRIPTION
- Remove initial ping from jumphost playbook because we no longer need
  to gather facts from the servers
- Use ansible's IP addresses for the servers and reverse lookup to get
  the hostnames to add to the list of target-hosts on the jumphost
- As a by-product, this fixes #23 