### PR TITLE
Update pcp configuration

### DIFF
--- a/playbooks/install-pcp-collector.yml
+++ b/playbooks/install-pcp-collector.yml
@@ -1,0 +1,8 @@
+# vim: set ts=2 sw=2 et :
+---
+
+- name: Install pcp on Gluster servers
+  hosts: gluster-servers
+  become: true
+  roles:
+  - pcp-collector

--- a/roles/gluster-volume/tasks/main.yml
+++ b/roles/gluster-volume/tasks/main.yml
@@ -91,6 +91,14 @@
       state: started
       name: "{{ volume }}"
 
+  # We enable profiling so that the gluster pmda can grab the stats
+  - name: Enable volume profiling
+    command: "gluster volume profile {{ volume }} start"
+    register: result
+    failed_when: "'started' not in result.stderr and
+                  'successful' not in result.stdout"
+    changed_when: "'successful' in result.stdout"
+
   # We set hard limit to 100 so that the soft limit percentage == actual
   # number.
   - name: Set snapshot hard limit

--- a/roles/pcp-aggregator/files/pcp2zabbix_with_gluster.sh
+++ b/roles/pcp-aggregator/files/pcp2zabbix_with_gluster.sh
@@ -1,0 +1,6 @@
+#! /bin/bash
+
+# The purpose of this wrapper script is to allow somw hosts to export gluster
+# metrics while others don't. So, we first try with, and if that fails, without.
+
+pcp2zabbix "$@" gluster || pcp2zabbix "$@"

--- a/roles/pcp-aggregator/tasks/main.yml
+++ b/roles/pcp-aggregator/tasks/main.yml
@@ -52,11 +52,17 @@
   with_items:
   - "{{ hostnames.results }}"
 
+- name: Add zabbix relay script
+  copy:
+    dest: /usr/local/bin/
+    src: pcp2zabbix_with_gluster.sh
+    mode: 0755
+
 - name: Relay metrics to Zabbix
   lineinfile:
     create: yes
-    regexp: '^pcp2zabbix '
-    line: "pcp2zabbix --lld -g {{ zabbix_server }} -E 60 -t 60 {{ pcp_metrics | join(' ') }}"
+    regexp: '^pcp2zabbix'
+    line: "pcp2zabbix_with_gluster.sh --lld -g {{ zabbix_server }} -E 60 -t 60 {{ pcp_metrics | join(' ') }}"
     path: /etc/pcp/pmmgr/monitor
     state: present
 

--- a/roles/pcp-collector/tasks/main.yml
+++ b/roles/pcp-collector/tasks/main.yml
@@ -22,4 +22,9 @@
     chdir: "/var/lib/pcp/pmdas/{{ item }}"
   with_items:
   - dm
-  #- gluster
+
+- name: Install Gluster pmda only on master nodes
+  shell: "echo b | ./Install"
+  args:
+    chdir: "/var/lib/pcp/pmdas/gluster"
+  when: group_names|join(" ") is search("tag_gluster_master")


### PR DESCRIPTION
- Enables Gluster PMDA
- Starts vol profiling on master
- Adds wrapper script to pcp2zabbix to handle only master exporting
gluster metrics

Signed-off-by: John Strunk <jstrunk@redhat.com>