### PR TITLE
Add config for starter-us-east-2

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -73,7 +73,11 @@ Vagrant.configure("2") do |config|
             "tag_gluster_master_us_east_1b_c00" => ["dummy"],
             "tag_gluster_group_us_east_1b_c00_g00" => ["dummy"],
             "tag_gluster_master_us_east_1b_c01" => ["dummy"],
-            "tag_gluster_group_us_east_1b_c01_g00" => ["dummy"]
+            "tag_gluster_group_us_east_1b_c01_g00" => ["dummy"],
+            "tag_gluster_master_us_east_2_c00" => ["dummy"],
+            "tag_gluster_group_us_east_2_c00_g00" => ["dummy"],
+            "tag_gluster_master_us_east_2_c01" => ["dummy"],
+            "tag_gluster_group_us_east_2_c01_g00" => ["dummy"]
           }
           ansible.limit = "all"
           ansible.playbook = "vagrant.yml"

--- a/group_vars/gluster-servers
+++ b/group_vars/gluster-servers
@@ -32,6 +32,22 @@ gluster_volumes:
     size: 500G
     device: /dev/xvdc
     group: tag_gluster_group_us_east_1b_c01_g00
+  supervole200:
+    size: 500G
+    device: /dev/xvdb
+    group: tag_gluster_group_us_east_2_c00_g00
+  supervole201:
+    size: 500G
+    device: /dev/xvdb
+    group: tag_gluster_group_us_east_2_c01_g00
+  supervole202:
+    size: 500G
+    device: /dev/xvdc
+    group: tag_gluster_group_us_east_2_c00_g00
+  supervole203:
+    size: 500G
+    device: /dev/xvdc
+    group: tag_gluster_group_us_east_2_c01_g00
   supervol00:
     size: 500G
     device: /dev/xvdb

--- a/inventory_groups
+++ b/inventory_groups
@@ -34,6 +34,24 @@ tag_gluster_group_us_east_1b_c01_g00
 
 
 
+#-- 2 cluster 00
+[g-us-east-2-c00:vars]
+cluster_master="{{ groups['tag_gluster_master_us_east_2_c00'][0] }}"
+cluster_member_group="g-us-east-2-c00"
+
+[g-us-east-2-c00:children]
+tag_gluster_group_us_east_2_c00_g00
+
+#-- 2 cluster 01
+[g-us-east-2-c01:vars]
+cluster_master="{{ groups['tag_gluster_master_us_east_2_c01'][0] }}"
+cluster_member_group="g-us-east-2-c01"
+
+[g-us-east-2-c01:children]
+tag_gluster_group_us_east_2_c01_g00
+
+
+
 #-- 2a cluster 00
 [g-us-east-2a-c00:vars]
 cluster_master="{{ groups['tag_gluster_master_us_east_2a_c00'][0] }}"
@@ -58,6 +76,8 @@ g-us-east-1a-c00
 g-us-east-1a-c01
 g-us-east-1b-c00
 g-us-east-1b-c01
+g-us-east-2-c00
+g-us-east-2-c01
 g-us-east-2a-c00
 g-us-east-2a-c01
 


### PR DESCRIPTION
Adds configuration for east-2 w/ 2 supervols/cluster.