### PR TITLE
Fix running shared storage across volumes and clusters

### DIFF
--- a/playbooks/gluster-volume.yml
+++ b/playbooks/gluster-volume.yml
@@ -20,8 +20,8 @@
   tasks:
   - include_role:
       name: gluster-secure-shared-storage
-    with_items: "{{ gluster_volumes }}"
-    when: "gluster_volumes is defined and
-           inventory_hostname in groups[gluster_volumes[volume].group]"
+    with_items: "{{ cluster_member_group }}"
+    when: "cluster_member_group is defined and
+           inventory_hostname in groups[member_group]"
     loop_control:
-      loop_var: volume
+      loop_var: member_group

--- a/playbooks/secure-shared-storage.yml
+++ b/playbooks/secure-shared-storage.yml
@@ -8,8 +8,8 @@
   tasks:
   - include_role:
       name: gluster-secure-shared-storage
-    with_items: "{{ gluster_volumes }}"
-    when: "gluster_volumes is defined and
-           inventory_hostname in groups[gluster_volumes[volume].group]"
+    with_items: "{{ cluster_member_group }}"
+    when: "cluster_member_group is defined and
+           inventory_hostname in groups[member_group]"
     loop_control:
-      loop_var: volume
+      loop_var: member_group

--- a/roles/gluster-secure-shared-storage/tasks/restrict_shared_storage.yml
+++ b/roles/gluster-secure-shared-storage/tasks/restrict_shared_storage.yml
@@ -17,12 +17,6 @@
     vars:
       gl_gluster_hosts: "{{ groups[hostvars[inventory_hostname].cluster_member_group] | difference(play_hosts) }}"
 
-  - name: Check if additional hosts that are not part of the gluster cluster are not part of the play
-    fail: msg="More hosts than ones that form the gluster cluster are part of the play, additional {{ gl_this_play_hosts }}"
-    when: gl_this_play_hosts|length != 0
-    vars:
-      gl_this_play_hosts: "{{ play_hosts | difference(groups[hostvars[inventory_hostname].cluster_member_group]) }}"
-
 # We unmount the shared storage volume using systemd and via a manual umount as,
 #   - Either fstab mounted it, in which case stopping it via systemd will not
 #     work


### PR DESCRIPTION
Currently shared storage TLS was being enabled across volumes
which causes checks to be put in place, to ensure that all hosts
that form the cluster are part of the play, and also repeats the
play for as many volumes there are.

Changed this to run per gluster cluster group, which restricts the
number of times this is called, and further removed the check on
extra hosts in the play, as the role is included only for those
hosts that are part of the cluster group and not others.

The gap now is, any filtered role invocation of secure-shared-storage
that does not include all hosts in the cluster, but all hosts are present
as part of the play_hosts, will pass scrutiny and get executed.

NOTE: The above is not possible when using the existing playbooks

This fixes #44

Signed-off-by: ShyamsundarR <srangana@redhat.com>