### PR TITLE
Directly probe for gluster metrics

### DIFF
--- a/roles/pcp-aggregator/files/pcp2zabbix_with_gluster.sh
+++ b/roles/pcp-aggregator/files/pcp2zabbix_with_gluster.sh
@@ -16,8 +16,11 @@ function gethost {
 
 remotehost=$(gethost "$@")
 
+# Collect samples for between 12 and 48 hrs before restarting
+samples=$((720 + RANDOM%2160))
+
 if pminfo -h "$remotehost" gluster >& /dev/null; then
-    pcp2zabbix "$@" gluster
+    pcp2zabbix "$@" gluster -s $samples
 else
-    pcp2zabbix "$@"
+    pcp2zabbix "$@" -s $samples
 fi

--- a/roles/pcp-aggregator/files/pcp2zabbix_with_gluster.sh
+++ b/roles/pcp-aggregator/files/pcp2zabbix_with_gluster.sh
@@ -1,6 +1,23 @@
 #! /bin/bash
 
 # The purpose of this wrapper script is to allow somw hosts to export gluster
-# metrics while others don't. So, we first try with, and if that fails, without.
+# metrics while others don't. So, we probe for the gluster metrics and use
+# the result to choose
 
-pcp2zabbix "$@" gluster || pcp2zabbix "$@"
+function gethost {
+    while [[ $# -gt 0 ]]; do
+        if [ "$1" == "-h" ]; then
+            echo "$2"
+            return
+        fi
+        shift
+    done
+}
+
+remotehost=$(gethost "$@")
+
+if pminfo -h "$remotehost" gluster >& /dev/null; then
+    pcp2zabbix "$@" gluster
+else
+    pcp2zabbix "$@"
+fi


### PR DESCRIPTION
Use `pminfo` to check for a host exporting gluster metrics instead of relying on the "fallthrough" we had before. Now that we properly probe, This PR also adds the periodic exit of `pcp2zabbix` so that it gets restarted and re-sends the low-level discovery info.

Fixes: #38 