### PR TITLE
Upgrade helper playbooks

### DIFF
--- a/ansible-ec2
+++ b/ansible-ec2
@@ -1,6 +1,8 @@
 #! /bin/bash
 
+export ANSIBLE_SHOW_CUSTOM_STATS=true
+
 ansible-playbook \
   -i ec2.py \
   -i inventory_groups \
-  $*
+  "$@"

--- a/ansible-vagrant
+++ b/ansible-vagrant
@@ -1,6 +1,8 @@
 #! /bin/bash
 
+export ANSIBLE_SHOW_CUSTOM_STATS=true
+
 ansible-playbook \
   -i .vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory \
   -i inventory_groups \
-  $*
+  "$@"

--- a/docs/server-upgrade.md
+++ b/docs/server-upgrade.md
@@ -2,6 +2,28 @@
 
 This document outlines procedures for upgrading the packages on Gluster servers.
 
+## Determining upgrade needs
+
+The playbook `playbooks/check-upgrade.yml` will count the total and
+security-specific package updates that are available. The playbook does not
+make any modifications to the hosts.
+
+Usage:
+
+```shell
+$ ./ansible-ec2 playbooks/check-upgrade.yml
+
+# ... ansible output ...
+CUSTOM STATS: ********************************************************
+        node3: { "security_updates": "0",  "total_updates": "11"}
+        jumper: { "security_updates": "0",  "total_updates": "2"}
+        node2: { "security_updates": "0",  "total_updates": "11"}
+        node1: { "security_updates": "0",  "total_updates": "11"}
+        node5: { "security_updates": "0",  "total_updates": "11"}
+        node0: { "security_updates": "0",  "total_updates": "11"}
+        node4: { "security_updates": "0",  "total_updates": "11"}
+```
+
 ## Automated upgrade
 
 The steps below have been automated via the `playbooks/upgrade.yml` Ansible

--- a/docs/server-upgrade.md
+++ b/docs/server-upgrade.md
@@ -31,9 +31,16 @@ playbook. This playbook will update all packages to their latest version (not
 just security updates), checking and waiting for the cluster to be healthy with
 each host upgraded.
 
+An optional playbook, `playbooks/download-upgrades.yml` is available to
+pre-download the available packages across all hosts to speed the upgrade
+process.
+
 Usage:
 
 ```shell
+$ ./ansible-ec2 playbooks/download-upgrades.yml
+# ... ansible output ...
+
 $ ./ansible-ec2 -l g-us-east-2-c00,g-us-east-2-c01 playbooks/upgrade.yml
 
 # ... ansible output ...

--- a/playbooks/check-upgrade.yml
+++ b/playbooks/check-upgrade.yml
@@ -1,0 +1,30 @@
+# vim: set ts=2 sw=2 et :
+---
+
+# This playbook will check the supplied hosts to see what upgrades are
+# available. It will not make any changes to the affected hosts.
+
+- hosts: all
+  become: true
+  gather_facts: false
+  tasks:
+    - name: Looking for all available updates
+      command: "yum -q updateinfo list"
+      args:
+        warn: false
+      register: updates
+      changed_when: false
+
+    - name: Looking for security updates
+      command: "yum -q updateinfo list security"
+      args:
+        warn: false
+      register: security
+      changed_when: false
+
+    - name: Collecting results
+      set_stats:
+        per_host: true
+        data:
+          security_updates: "{{ security.stdout_lines|length }}"
+          total_updates: "{{ updates.stdout_lines|length }}"

--- a/playbooks/download-upgrades.yml
+++ b/playbooks/download-upgrades.yml
@@ -1,0 +1,15 @@
+# vim: set ts=2 sw=2 et :
+---
+
+# This playbook will pre-download all available package updates, but it will
+# not install or otherwise make changes to the hosts.
+
+- hosts: all
+  become: true
+  gather_facts: false
+  tasks:
+    - name: Downloading available package updates
+      command: "yum update --downloadonly"
+      args:
+        warn: false
+      changed_when: false


### PR DESCRIPTION
In thinking through yesterday's upgrades, I decided to put together these helper playbooks:
- Summarize (count) available & security updates on each host
- Pre-download updates in parallel on all hosts

No real ninja moves here, just hopefully useful stuff. Though I will mention the use of `{{ foo.stdout_lines|length }}` as a better(?) method of counting output lines than the shell module piped through `wc -l`