### PR TITLE
Add 3 nodes for free-stg environment

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -66,6 +66,8 @@ Vagrant.configure("2") do |config|
               "node5"
             ],
             # tags that need to exist for the config to parse correctly
+            "tag_gluster_master_free_stg_c00" => ["dummy"],
+            "tag_gluster_group_free_stg_c00_g00" => ["dummy"],
             "tag_gluster_master_us_east_1a_c00" => ["dummy"],
             "tag_gluster_group_us_east_1a_c00_g00" => ["dummy"],
             "tag_gluster_master_us_east_1a_c01" => ["dummy"],

--- a/group_vars/gluster-servers
+++ b/group_vars/gluster-servers
@@ -1,5 +1,9 @@
 # Defines the volumes exported by gluster
 gluster_volumes:
+  supervolfs00:
+    size: 500G
+    device: /dev/xvdb
+    group: tag_gluster_group_free_stg_c00_g00
   supervole1a00:
     size: 500G
     device: /dev/xvdb

--- a/inventory_groups
+++ b/inventory_groups
@@ -1,3 +1,11 @@
+#-- free-stg
+[g-free-stg-c00:vars]
+cluster_master="{{ groups['tag_gluster_master_free_stg_c00'][0] }}"
+cluster_member_group="g-free-stg-c00"
+
+[g-free-stg-c00:children]
+tag_gluster_group_free_stg_c00_g00
+
 #-- 1a cluster 00
 [g-us-east-1a-c00:vars]
 cluster_master="{{ groups['tag_gluster_master_us_east_1a_c00'][0] }}"
@@ -72,6 +80,7 @@ tag_gluster_group_us_east_2a_c01_g00
 
 [gluster-servers:children]
 # List all clusters as children of gluster-servers
+g-free-stg-c00
 g-us-east-1a-c00
 g-us-east-1a-c01
 g-us-east-1b-c00


### PR DESCRIPTION
This PR adds 3-nodes for the free-stg environment. That env only has 100 GB disks, but we are applying the full capacities and PV count for that 1 cluster anyway.