### PR TITLE
Make stopping of gluster work for non-servers, too

### DIFF
--- a/roles/upgrade/tasks/main.yml
+++ b/roles/upgrade/tasks/main.yml
@@ -41,12 +41,19 @@
       systemd:
         name: glusterd
         state: stopped
+      when: inventory_hostname in groups['gluster-servers']
 
+    # We allow success for rc == 0 or 1 (success or process not found) to
+    # handle cases where there are no glusterfs(d) processes on the machine
     - name: Stop glusterfs
       command: "pkill glusterfs"
+      register: result
+      failed_when: result.rc != 0 and result.rc != 1
 
     - name: Stop glusterfsd
       command: "pkill glusterfsd"
+      register: result
+      failed_when: result.rc != 0 and result.rc != 1
 
 - when: gupdate or (update_count|int > 0)
   block:


### PR DESCRIPTION
When gluster packages are going to be upgraded, all gluster processes should be stopped. The existing code worked fine for machines that were 'gluster-servers' because they had each of these type of processes running. Unfortunately, the tasks failed for non-servers because the processes weren't there.

This change doesn't try to stop glusterd if it's not a server, and allows the `pkill` to fail if it can't find the named processes (which may or may not be there for non-servers).

Tested against jump-host and free-stg.