### PR TITLE
Add playbook that enables full corefile capture via ccpp

### DIFF
--- a/playbooks/enable-core-files.yml
+++ b/playbooks/enable-core-files.yml
@@ -1,0 +1,21 @@
+# vim: set ts=2 sw=2 et :
+---
+
+# This playbook will ensure core files are captured via abrtd & ccpp
+
+- hosts: all
+  become: true
+  tasks:
+    - name: Enable saving full cores via ccpp
+      lineinfile:
+        path: /etc/abrt/plugins/CCpp.conf
+        regexp: "^SaveFullCore"
+        line: "SaveFullCore=yes"
+        state: present
+      register: res
+
+    - name: Restart abrtd
+      systemd:
+        name: abrtd
+        state: restarted
+      when: res.changed


### PR DESCRIPTION
Something broke coredumps during the upgrade that included gluster 3.3.1 ==> 3.4.

This playbook enables full corefile capture when processed via ccpp and abrtd.

Cores end up in `/var/tmp/ccpp*` instead of `/` as they used to.