### PR TITLE
Enable pmie on hosts

### DIFF
--- a/roles/pcp-base/tasks/main.yml
+++ b/roles/pcp-base/tasks/main.yml
@@ -21,3 +21,4 @@
     state: restarted
   with_items:
   - pmcd
+  - pmie


### PR DESCRIPTION
The gluster pmda (running on the gluster masters) crashes periodically.
pmcd, which is responsible for starting it, doesn't do a good job of
re-starting it. pmie is recommended for this task. This patch enables
pmie on all hosts to ensure the pmdas are properly restarted if
necessary.

Signed-off-by: John Strunk <jstrunk@redhat.com>