### PR TITLE
Restarts pmie after restarting pmcd

### DIFF
--- a/playbooks/restart-pcp.yml
+++ b/playbooks/restart-pcp.yml
@@ -11,6 +11,12 @@
         enabled: true
         state: restarted
 
+    - name: Restart pmie
+      systemd:
+        name: pmie
+        enabled: true
+        state: restarted
+
 - name: Restart pcp daemons on Jump host
   hosts: gluster_mgmt
   become: true


### PR DESCRIPTION
It appears that if pmcd service gets restarted, pmie also requires a
restart for it to continue to watch pmcd's sub processes.

Signed-off-by: John Strunk <jstrunk@redhat.com>