### PR TITLE
Changes command used to wait for pending heals

### DIFF
--- a/docs/node-reboot.md
+++ b/docs/node-reboot.md
@@ -48,7 +48,7 @@ state > start`)
 - Make sure the bricks are up by checking `sudo gluster vol status <volname>`
   for each volume serverd by the affected node.
 - Monitor the healing of each volume via `sudo gluster vol heal <volname>
-  statistics heal-count`. The "number of entries" should steadily decrease to
+  info summary`. The "number of entries" should steadily decrease to
   zero.
 - Once the heal count has reached a minimum (or zero), `sudo gluster vol heal
   <volname> info` can be used to verify and/or get a list of the remaining

--- a/docs/server-upgrade.md
+++ b/docs/server-upgrade.md
@@ -146,7 +146,7 @@ fully upgrade the server (all packages).
 
     ```shell
     $ sudo gluster vol status
-    $ sudo gluster vol heal <volname> statistics heal-count
+    $ sudo gluster vol heal <volname> info summary
     # ... repeat above until the count is low ...
     $ sudo gluster vol heal <volname> info
     ```

--- a/roles/upgrade/tasks/wait_for_heals.yml
+++ b/roles/upgrade/tasks/wait_for_heals.yml
@@ -12,8 +12,8 @@
 # instead of showing a number, so this serves as a check that bricks are up,
 # too.
 - name: Wait for heal count to be 0
-  shell: "gluster vol heal {{ vol }} statistics heal-count |
-          grep 'entries: 0' | wc -l"
+  shell: "gluster vol heal {{ vol }} info summary |
+          grep 'Total Number of entries: 0' | wc -l"
   changed_when: false
   register: result
   until: result.stdout == "3"


### PR DESCRIPTION
During the last upgrade, it was noticed that the pending heal count
tended to not decrease until 'gluster v heal info' was run, then it
would suddenly be zero. When investigating this behavior, I was told
the 'heal statistics' family of commands are not supported. The above
problem was seen while looking at pending heals via 'gluster vol heal
statistics heal-count'. Advice was to use 'v heal info summary' instead.
This change implements the above advice.

Signed-off-by: John Strunk <jstrunk@redhat.com>