### PR TITLE
Re-enable glusterd autorestart

### DIFF
--- a/playbooks/enable-gd-autorestart.yml
+++ b/playbooks/enable-gd-autorestart.yml
@@ -1,0 +1,27 @@
+---
+# vim: set ts=2 sw=2 et :
+
+- hosts: gluster-servers
+  become: true
+  tasks:
+    - name: Enable systemd to auto-restart glusterd
+      lineinfile:
+        state: present
+        insertafter: "^\\[Service\\]"
+        # Ensure only 1 key= instance exists, and only match left of equal
+        # so we can change the value, too
+        regexp: "{{ item | regex_search('^(.*=)') }}"
+        line: "{{ item }}"
+        path: /usr/lib/systemd/system/glusterd.service
+      with_items:
+        - "RestartSec=60"
+        - "Restart=on-abnormal"
+        # Old setting name for interval
+        - "StartLimitInterval=3600"
+        # New setting name for interval
+        - "StartLimitIntervalSec=3600"
+        - "StartLimitBurst=3"
+
+    - name: Reload systemd configuration
+      systemd:
+        daemon_reload: true

--- a/roles/upgrade/tasks/main.yml
+++ b/roles/upgrade/tasks/main.yml
@@ -63,6 +63,30 @@
         state: latest
       register: system_updated
 
+    # When gluster gets upgraded, it removes our previous customization. This
+    # puts it back.
+    - name: Enable systemd to auto-restart glusterd
+      lineinfile:
+        state: present
+        insertafter: "^\\[Service\\]"
+        # Ensure only 1 key= instance exists, and only match left of equal
+        # so we can change the value, too
+        regexp: "{{ item | regex_search('^(.*=)') }}"
+        line: "{{ item }}"
+        path: /usr/lib/systemd/system/glusterd.service
+      with_items:
+        - "RestartSec=60"
+        - "Restart=on-abnormal"
+        # Old setting name for interval
+        - "StartLimitInterval=3600"
+        # New setting name for interval
+        - "StartLimitIntervalSec=3600"
+        - "StartLimitBurst=3"
+
+    - name: Reload systemd configuration
+      systemd:
+        daemon_reload: true
+
     - name: Reboot after upgrade
       include_role:
         name: "reboot-system"


### PR DESCRIPTION
During the last upgrade, the customization to have gd automatically
restart was lost. This commit adds a playbook to re-enable it, and it
modifies the upgrade playbook to re-apply the changes on each upgrade.

Signed-off-by: John Strunk <jstrunk@redhat.com>