### PR TITLE
Update mount options for bricks

### DIFF
--- a/roles/gluster-volume/tasks/mk_volume.yml
+++ b/roles/gluster-volume/tasks/mk_volume.yml
@@ -55,7 +55,7 @@
 - name: Mount brick
   mount:
     fstype: xfs
-    opts: inode64,discard,prjquota
+    opts: inode64,discard,prjquota,x-systemd.device-timeout=10min
     path: /bricks/{{ volume }}
     src: /dev/mapper/{{ volume }}-{{ volume }}
     state: mounted


### PR DESCRIPTION
This adds the following mount option for bricks:
- x-systemd.device-timeout=10min

Device timeout is necessary because sometimes LVM takes a long time to
start the device, causing the mount to fail w/ the default timeout.
Failures make the machine unbootable.

**Note:** All existing brick mounts have been updated via a separate Ansible playbook.