### PR TITLE
Add zabbix impersonator monitor endpoint

### DIFF
--- a/roles/pcp-aggregator/tasks/main.yml
+++ b/roles/pcp-aggregator/tasks/main.yml
@@ -59,10 +59,11 @@
     mode: 0755
 
 - name: Relay metrics to Zabbix
-  lineinfile:
+  blockinfile:
     create: yes
-    regexp: '^pcp2zabbix'
-    line: "pcp2zabbix_with_gluster.sh --zabbix-lld -g {{ zabbix_server }} -E 60 -t 60 {{ pcp_metrics | join(' ') }}"
+    block: |
+      pcp2zabbix_with_gluster.sh --zabbix-lld -g {{ zabbix_server }} -E 60 -t 60 {{ pcp_metrics | join(' ') }}
+      pcp2zabbix_with_gluster.sh --zabbix-lld -g {{ zabbix_impersonator_server }} -E 60 -t 60 {{ pcp_metrics | join(' ') }}
     path: /etc/pcp/pmmgr/monitor
     state: present
 

--- a/roles/pcp-aggregator/vars/main.yml
+++ b/roles/pcp-aggregator/vars/main.yml
@@ -1,4 +1,5 @@
 zabbix_server: zabbix.devshift.net
+zabbix_impersonator_server: zabbix-impersonator-trapper.devshift.net
 
 pcp_metrics:
 - disk.dev.read


### PR DESCRIPTION
This PR changes the pmmgr monitor configuration to manage two lines in /etc/pcp/pmmgr/monitor

The first line is the same as before, the second one will target a new service which purpose is to expose the same metrics in prometheus format

The change from lineinfile to blockinfile requires ansible 2.9.x

Before applying this change, the file /etc/pcp/pmmgr/monitor should be removed. This is because blockinfile searches for beginning and eng markers in the file to find the block it manages. Since those are not present, it will append to the file, which will cause duplicate lines.