### PR TITLE
Remove old zabbix server

### DIFF
--- a/roles/pcp-aggregator/tasks/main.yml
+++ b/roles/pcp-aggregator/tasks/main.yml
@@ -59,11 +59,10 @@
     mode: 0755
 
 - name: Relay metrics to Zabbix
-  blockinfile:
+  lineinfile:
     create: yes
-    block: |
-      pcp2zabbix_with_gluster.sh --zabbix-lld -g {{ zabbix_server }} -E 60 -t 60 {{ pcp_metrics | join(' ') }}
-      pcp2zabbix_with_gluster.sh --zabbix-lld -g {{ zabbix_impersonator_server }} -E 60 -t 60 {{ pcp_metrics | join(' ') }}
+    regexp: '^pcp2zabbix'
+    line: "pcp2zabbix_with_gluster.sh --zabbix-lld -g {{ zabbix_server }} -E 60 -t 60 {{ pcp_metrics | join(' ') }}"
     path: /etc/pcp/pmmgr/monitor
     state: present
 

--- a/roles/pcp-aggregator/vars/main.yml
+++ b/roles/pcp-aggregator/vars/main.yml
@@ -1,5 +1,4 @@
-zabbix_server: zabbix.devshift.net
-zabbix_impersonator_server: zabbix-impersonator-trapper.devshift.net
+zabbix_server: zabbix-impersonator-trapper.devshift.net
 
 pcp_metrics:
 - disk.dev.read


### PR DESCRIPTION
Removes old zabbix server and returns structure of ansible to what it was before we had 2 destinations.