### PR TITLE
Add a daily call to fstrim

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,8 +15,8 @@ Vagrant.configure("2") do |config|
   end
 
   # Can't write to /vagrant on atomic-host, so disable default sync dir
-  #config.vm.synced_folder ".", "/vagrant", disabled: true
-  config.vm.synced_folder ".", "/vagrant", type: "sshfs"
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+  #config.vm.synced_folder ".", "/vagrant", type: "sshfs"
 
 
   config.vm.define "jumper" do |node|

--- a/roles/gluster-server/tasks/main.yml
+++ b/roles/gluster-server/tasks/main.yml
@@ -62,6 +62,14 @@
     name: glusterd
     state: started
 
+- name: Add daily fstrim of filesystems
+  lineinfile:
+    create: yes
+    regexp: 'fstrim'
+    line: "55 23 * * * root /usr/sbin/fstrim -a"
+    path: /etc/cron.d/fstrim-devices
+    state: present
+
 - name: Install additional packages
   package:
     name: "{{ item }}"


### PR DESCRIPTION
Even though the bricks are mounted w/ -odiscard, wasted space seems to
accumulate over time. This adds a daily call to fstrim to clean up prior
to the daily snapshot being taken.